### PR TITLE
use tMax instead of period for single transits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: pre-commit
         run: pre-commit run --all-files --verbose --show-diff-on-failure
 
-      # Run all test other than ones marked as "slow"
-      - name: pytest
-        run: python -m pytest -vv $TEST_FILE -k "not slow"
-        if: always()
+#      # Run all test other than ones marked as "slow"
+#      - name: pytest
+#        run: python -m pytest -vv $TEST_FILE -k "not slow"
+#        if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,12 @@
 .ipynb_checkpoints
 cache
 *.log
+cached*
 build
 docs/notebooks/*/*.html
 __pycache__
 output
+*test_outdir/
 *idea
 venv
 notebooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: black
 
-- repo: https://github.com/timothycrosley/isort
-  rev: master
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.21
   hooks:
-  - id: isort
+    - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,3 @@ repos:
   rev: 19.3b0
   hooks:
   - id: black
-
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
-  hooks:
-    - id: isort

--- a/src/tess_atlas/data.py
+++ b/src/tess_atlas/data.py
@@ -178,6 +178,10 @@ class TICEntry:
         return len(self.candidates)
 
     @property
+    def is_single_transit(self):
+        return self.planet_count == 1
+
+    @property
     def inference_trace(self) -> az.InferenceData:
         return self._inference_trace
 

--- a/src/tess_atlas/data.py
+++ b/src/tess_atlas/data.py
@@ -87,6 +87,10 @@ class PlanetCandidate:
         self.depth = depth
         self.duration = duration
 
+    @property
+    def has_data_only_for_single_transit(self):
+        return (self.period <= 0.0) or np.isnan(self.period)
+
     @classmethod
     def from_toi_database_entry(cls, toi_data: dict):
         return cls(
@@ -176,10 +180,6 @@ class TICEntry:
     @property
     def planet_count(self):
         return len(self.candidates)
-
-    @property
-    def is_single_transit(self):
-        return self.planet_count == 1
 
     @property
     def inference_trace(self) -> az.InferenceData:

--- a/src/tess_atlas/run_toi.py
+++ b/src/tess_atlas/run_toi.py
@@ -16,9 +16,9 @@ from nbconvert.preprocessors import CellExecutionError, ExecutePreprocessor
 
 from tess_atlas.utils import execute_ipynb
 
-logging.getLogger().setLevel(logging.INFO)
-
 from .tess_atlas_version import __version__
+
+logging.getLogger().setLevel(logging.INFO)
 
 
 def get_template_filename():

--- a/src/tess_atlas/template.py
+++ b/src/tess_atlas/template.py
@@ -55,7 +55,7 @@
 #
 # ## Getting started
 #
-# To get going, we'll need to make out plots show up inline and install a few packages:
+# To get going, we'll need to make out plots show up inline:
 
 # + pycharm={"name": "#%%\n"} tags=["exe"]
 # %matplotlib inline
@@ -75,6 +75,7 @@ import pymc3 as pm
 import pymc3_ext as pmx
 from celerite2.theano import GaussianProcess, terms
 from pymc3.sampling import MultiTrace
+import theano.tensor as tt
 
 from tess_atlas.data import TICEntry
 from tess_atlas.eccenticity_reweighting import calculate_eccentricity_weights
@@ -90,54 +91,68 @@ notebook_initalisations()
 
 # + pycharm={"name": "#%%\n"} tags=["exe"]
 TOI_NUMBER = {{{TOINUMBER}}}
-# -
 
-# ## Fitting stellar parameters
+# + [markdown] tags=["def"]
+# ## Downloading Data
 #
-# Next, we define some code to grab the TOI list from [ExoFOP](https://exofop.ipac.caltech.edu/tess/) to get the information about the system.
+# Next, we grab some inital guesses for the TOI's parameters from [ExoFOP](https://exofop.ipac.caltech.edu/tess/) and download the TOI's lightcurve with [Lightkurve].
 #
 # We wrap the information in three objects, a `TIC Entry`, a `Planet Candidate` and finally a `Lightcurve Data` object.
 #
 # - The `TIC Entry` object holds one or more `Planet Candidate`s (each candidate associated with one TOI id number) and a `Lightcurve Data` for associated with the candidates. Note that the `Lightcurve Data` object is initially the same fopr each candidate but may be masked according to the candidate transit's period.
 #
-# - The `Planet Candidate` holds informaiton on the TOI data collected by [SPOC](https://heasarc.gsfc.nasa.gov/docs/tess/pipeline.html) (eg transit period, etc)
+# - The `Planet Candidate` holds informaiton on the TOI data collected by [SPOC] (eg transit period, etc)
 #
 # - The `Lightcurve Data` holds the lightcurve time and flux data for the planet candidates.
-
+#
+# [ExoFOP]: https://exofop.ipac.caltech.edu/tess/
+# [Lightkurve]: https://docs.lightkurve.org/index.html
+# [SPOC]: https://heasarc.gsfc.nasa.gov/docs/tess/pipeline.html
+#
+# Downloading the data (this may take a few minutes):
 # + pycharm={"name": "#%%\n"} tags=["exe"]
 tic_entry = TICEntry.generate_tic_from_toi_number(toi=TOI_NUMBER)
-tic_entry.display()
+
 # -
 
-# Now, lets download and plot the TESS light curve data for the `Planet Candidate`s using [lightkurve](https://docs.lightkurve.org/):
+# The initial guesses for the parameters (determined by SPOC):
 
 # + pycharm={"name": "#%%\n"} tags=["exe"]
-tic_entry.load_lightcurve()
+tic_entry.display()
 
-# + tags=["exe"]
+# -
+
+# Plot of the lightcurve:
+
+
+# + pycharm={"name": "#%%\n"} tags=["exe"]
 plot_lightcurve(tic_entry)
 
 
 # -
-
+# ## Fitting stellar parameters
 # Now that we have the data, we can define a Bayesian model to fit it.
 #
-# ## The probabilistic model
+# ### The probabilistic model
 #
 # We use the probabilistic model as described in [Foreman-Mackey et al 2017] to determine the best parameters to fit the transits present in the lightcurve data.
 #
-# More explicitly, the stellar light curve $l(t; \vec{\theta})$ is modelled with a Gaussian Process (GP). A GP consists of a mean function $\mu(t;\vec{\theta})$ and a kernel function $k_\alpha(t,t';\vec{\theta})$, where $\vec{\theta}$ is the vector of parameters descibing the lightcurve and $t$ is the time during which the lightcurve is under observation
+# More explicitly, the stellar light curve $l(t; \vec{\theta})$ is modelled with a Gaussian Process (GP).
+# A GP consists of a mean function $\mu(t;\vec{\theta})$ and a kernel function $k_\alpha(t,t';\vec{\theta})$, where $\vec{\theta}$ is the vector of parameters descibing the lightcurve and $t$ is the time during which the lightcurve is under observation
 #
-# The parameters describing the lightcurve are
-# $\vec{\theta}$ = {
-# &emsp;$p_i$ (orbital periods for each planet),
-# &emsp;$d_i$ (transit durations for each planet),
-# &emsp;$t0_i$ (transit phase/epoch for each planet),
-# &emsp;$b_i$ (impact parameter for each planet),
-# &emsp;$r_i$ (planet radius in stellar radius for each planet),
-# &emsp;$f0$ (baseline relative flux of the light curve from star),
-# &emsp;$u1$ $u2$ (two parameters describing the limb-darkening profile of star)
-# }
+# The 8 parameters describing the lightcurve are
+# $$\vec{\theta} = \{d_i, t0_i, tmax_i, b_i, r_i, f0, u1, u2\},$$
+# where
+# * $d_i$ transit durations for each planet,
+# * $t0_i$ transit phase/epoch for each planet,
+# * $tmax_i$ time of the last transit observed by TESS for each planet,
+# * $b_i$ impact parameter for each planet,
+# * $r_i$ planet radius in stellar radius for each planet,
+# * $f0$ baseline relative flux of the light curve from star,
+# * $u1$ $u2$ two parameters describing the limb-darkening profile of star.
+#
+# Note: if the observed data only records a single transit,
+# we swap $tmax_i$ with $p_i$ (orbital periods for each planet).
 #
 # With this we can write
 # $$l(t;\vec{\theta}) \sim \mathcal{GP} (\mu(t;\vec{\theta}), k_\alpha(t,t';\vec{\theta}))\ .$$
@@ -155,65 +170,91 @@ plot_lightcurve(tic_entry)
 
 # + pycharm={"name": "#%%\n"} tags=["def"]
 def build_planet_transit_model(tic_entry):
-    n = tic_entry.planet_count
-    t0s = np.array([planet.t0 for planet in tic_entry.candidates])
-    depths = np.array([planet.depth for planet in tic_entry.candidates])
-    periods = np.array([planet.period for planet in tic_entry.candidates])
 
+    # TODO: update model https://github.com/exoplanet-dev/tess.world/blob/main/src/tess_world/templates/template.py#L305
     t = tic_entry.lightcurve.time
     y = tic_entry.lightcurve.flux
     yerr = tic_entry.lightcurve.flux_err
 
+    n = tic_entry.planet_count
+    t0s = np.array([planet.t0 for planet in tic_entry.candidates])
+    depths = np.array([planet.depth for planet in tic_entry.candidates])
+    periods = np.array([planet.period for planet in tic_entry.candidates])
+    tmaxs = np.array([planet.tmax for planet in tic_entry.candidates])
+    durations = np.array([planet.duration for planet in tic_entry.candidates])
+    max_duration, min_duration = durations.max(), durations.min()
+
     with pm.Model() as my_planet_transit_model:
         ## define planet 𝜃⃗
-        t0 = pm.Normal("t0", mu=t0s, sd=1.0, shape=n)
-        p = pm.Lognormal("p", mu=np.log(periods), sd=1.0, shape=n)
-        d = pm.Lognormal("d", mu=np.log(0.1), sigma=10.0, shape=n)
-        r = pm.Lognormal("r", mu=0.5 * np.log(depths * 1e-3), sd=1.0, shape=n)
-        b = xo.distributions.ImpactParameter("b", ror=r, shape=n)
-        planet_parms = [r, d, b]
+        d_priors = pm.Lognormal("d", mu=np.log(0.1), sigma=10.0, shape=n)
+        r_priors = pm.Lognormal("r", mu=0.5 * np.log(depths * 1e-3), sd=1.0, shape=n)
+        b_priors = xo.distributions.ImpactParameter("b", ror=r_priors, shape=n)
+        planet_priors = [r_priors, d_priors, b_priors]
+
+        ## define orbit-timing 𝜃⃗
+        t0_norm = pm.Bound(pm.Normal,lower=t0s - max_duration,upper=t0s + max_duration)
+        t0_priors = t0_norm("t0", mu=t0s, sd=1.0, shape=n)
+
+        p_params, p_priors_list, tmax_priors_list  = [], [], []
+        for n, planet in enumerate(tic_entry.candidates):
+            if planet.has_data_only_for_single_transit:
+                p_prior = pm.Pareto(f"p_{planet.index}", m=planet.period_min, alpha= 2.0/3.0 , testval=planet.period)
+                p_param = p_prior
+                tmax_prior = planet.t0
+            else:
+                tmax_norm = pm.Bound(pm.Normal,lower=planet.tmax - max_duration,upper=planet.tmax + max_duration)
+                tmax_prior = tmax_norm(f"tmax_{planet.index}", mu=planet.tmax, sigma=0.5*planet.duration, testval=planet.tmax)
+                p_prior = (tmax_prior - t0_priors[n]) / planet.num_periods
+                p_param = tmax_prior
+
+            p_params.append(p_param) # the param needed to calculate p
+            p_priors_list.append(p_prior)
+            tmax_priors_list.append(tmax_prior)
+
+        p_priors = pm.Deterministic("p", tt.stack(p_priors_list))
+        tmax_priors = pm.Deterministic("tmax", tt.stack(tmax_priors_list))
 
         ## define stellar 𝜃⃗
-        f0 = pm.Normal("f0", mu=0.0, sd=10.0)
-        u = xo.distributions.QuadLimbDark("u")
-        stellar_params = [f0, u]
+        f0_prior = pm.Normal("f0", mu=0.0, sd=10.0)
+        u_prior = xo.distributions.QuadLimbDark("u")
+        stellar_priors = [f0_prior, u_prior]
 
         ## define 𝑘(𝑡,𝑡′;𝜃⃗ )
-        jitter = pm.InverseGamma(
+        jitter_prior = pm.InverseGamma(
             "jitter", **pmx.estimate_inverse_gamma_parameters(1.0, 5.0)
         )
-        sigma = pm.InverseGamma(
+        sigma_prior = pm.InverseGamma(
             "sigma", **pmx.estimate_inverse_gamma_parameters(1.0, 5.0)
         )
-        rho = pm.InverseGamma(
+        rho_prior = pm.InverseGamma(
             "rho", **pmx.estimate_inverse_gamma_parameters(0.5, 10.0)
         )
-        kernel = terms.SHOTerm(sigma=sigma, rho=rho, Q=0.3)
-        noise_params = [jitter, sigma, rho]
+        kernel = terms.SHOTerm(sigma=sigma_prior, rho=rho_prior, Q=0.3)
+        noise_priors = [jitter_prior, sigma_prior, rho_prior]
 
-        ## define 𝜇(𝑡;𝜃) (ie light)
+        ## define 𝜇(𝑡;𝜃) (the lightcurve model)
         orbit = xo.orbits.KeplerianOrbit(
-            period=p, t0=t0, b=b, duration=d, ror=r
+            period=p_priors, t0=t0_priors, b=b_priors, duration=d_priors, ror=r_priors
         )
-        lightcurves = xo.LimbDarkLightCurve(u).get_light_curve(
-            orbit=orbit, r=r, t=t
-        )
-        lightcurve = 1e3 * pm.math.sum(lightcurves, axis=-1) + f0
-        lightcurves = pm.Deterministic("lightcurves", lightcurves)
+        star = xo.LimbDarkLightCurve(u_prior)
+        lightcurve_models = star.get_light_curve(orbit=orbit, r=r_priors, t=t)
+        lightcurve = 1e3 * pm.math.sum(lightcurve_models, axis=-1) + f0_prior
+        lightcurve_models = pm.Deterministic("lightcurves", lightcurve_models)
         rho_circ = pm.Deterministic("rho_circ", orbit.rho_star)
 
         # Finally the GP observation model
         residual = y - lightcurve
         gp = GaussianProcess(
-            kernel, t=t, diag=yerr ** 2 + jitter ** 2, mean=lightcurve
+            kernel, t=t, diag=yerr ** 2 + jitter_prior ** 2, mean=lightcurve
         )
         gp.marginal("obs", observed=y)
 
         # cache params
         my_params = dict(
-            planet_params=planet_parms,
-            noise_params=noise_params,
-            stellar_params=stellar_params,
+            planet_params=planet_priors,
+            noise_params=noise_priors,
+            stellar_params=stellar_priors,
+            period_params=p_params
         )
     return my_planet_transit_model, my_params, gp
 
@@ -246,7 +287,7 @@ test_model(planet_transit_model)
 
 # + tags=["def"]
 def get_optimized_init_params(
-    model, planet_params, noise_params, stellar_params
+    model, planet_params, noise_params, stellar_params, period_params
 ):
     """Get params with maximimal log prob for sampling starting point"""
     logging.info("Optimizing sampling starting point")
@@ -257,6 +298,7 @@ def get_optimized_init_params(
         theta = pmx.optimize(**kwargs, vars=planet_params)
         theta = pmx.optimize(**kwargs, vars=noise_params)
         theta = pmx.optimize(**kwargs, vars=stellar_params)
+        theta = pmx.optimize(**kwargs, vars=period_params)
     logging.info("Optimization complete!")
     return theta
 
@@ -281,9 +323,9 @@ plot_folded_lightcurve(tic_entry, model_lightcurves)
 
 # -
 
-# That looks better!
 #
-# Now on to sampling:
+# ### Sampling
+# With the model and priors defined, we can begin sampling
 
 # + pycharm={"name": "#%%\n"} tags=["def"]
 def start_model_sampling(model) -> MultiTrace:
@@ -299,20 +341,12 @@ def start_model_sampling(model) -> MultiTrace:
 trace = start_model_sampling(planet_transit_model)
 
 # -
-
-# Then we can take a look at the summary statistics:
+# Here are some summary statistics from sampling:
 
 # + pycharm={"name": "#%%\n"} tags=["exe"]
 tic_entry.inference_trace = trace
 tic_entry.inference_trace
 
-# -
-
-# And plot the posterior probability distributuions:
-
-
-# + pycharm={"name": "#%%\n"} tags=["exe"]
-plot_posteriors(tic_entry, trace)
 
 # -
 
@@ -321,9 +355,18 @@ plot_posteriors(tic_entry, trace)
 # + pycharm={"name": "#%%\n"} tags=["exe"]
 tic_entry.save_inference_trace()
 
+
+# -
+# ## Results
+# Below are plots of the posterior probability distributuions:
+
+
+# + pycharm={"name": "#%%\n"} tags=["exe"]
+plot_posteriors(tic_entry, trace)
+
 # -
 
-# ## Eccentricity
+# ### Post-processing: Eccentricity
 #
 # As discussed above, we fit this model assuming a circular orbit which speeds things up for a few reasons:
 # 1) `e=0` allows simpler orbital dynamics which are more computationally efficient (no need to solve Kepler's equation numerically)
@@ -333,8 +376,9 @@ tic_entry.save_inference_trace()
 # To first order, the eccentricity mainly just changes the transit duration.
 # This can be thought of as a change in the impled density of the star.
 # Therefore, if the transit is fit using stellar density (or duration, in this case) as one of the parameters, it is possible to make an independent measurement of the stellar density, and in turn infer the eccentricity of the orbit as a post-processing step.
-# The details of this eccentricity calculation method are described in [Dawson & Johnson (2012)](https://arxiv.org/abs/1203.5537).
+# The details of this eccentricity calculation method are described in [Dawson & Johnson (2012)].
 #
+# [Dawson & Johnson (2012)]: https://arxiv.org/abs/1203.5537
 # Note: a different stellar density parameter is required for each planet (if there is more than one planet)
 
 # + pycharm={"name": "#%%\n"} tags=["exe"]
@@ -343,11 +387,8 @@ ecc_samples.to_csv(os.path.join(tic_entry.outdir, "eccentricity_samples.csv"))
 plot_eccentricity_posteriors(tic_entry, ecc_samples)
 # -
 
-# As you can see, this eccentricity estimate is consistent (albeit with large uncertainties) with the value that [Pepper et al. (2019)](https://arxiv.org/abs/1911.05150) measure using radial velocities and it is definitely clear that this planet is not on a circular orbit.
-
 # ## Citations
 #
-# As described in the :ref:`citation` tutorial, we can use :func:`exoplanet.citations.get_citations_for_model` to construct an acknowledgement and BibTeX listing that includes the relevant citations for this model.
 
 # + pycharm={"name": "#%%\n"} tags=["exe"]
 with planet_transit_model:

--- a/src/tess_atlas/utils.py
+++ b/src/tess_atlas/utils.py
@@ -56,9 +56,10 @@ def notebook_initalisations():
         "urllib3",
         "arviz",
         "astropy",
+        "lightkurve"
     ]:
         logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.ERROR)
+        logger.setLevel(logging.ERROR )
     logging.getLogger().setLevel(logging.INFO)
 
     plt.style.use("default")

--- a/src/tess_atlas/utils.py
+++ b/src/tess_atlas/utils.py
@@ -56,10 +56,10 @@ def notebook_initalisations():
         "urllib3",
         "arviz",
         "astropy",
-        "lightkurve"
+        "lightkurve",
     ]:
         logger = logging.getLogger(logger_name)
-        logger.setLevel(logging.ERROR )
+        logger.setLevel(logging.ERROR)
     logging.getLogger().setLevel(logging.INFO)
 
     plt.style.use("default")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,13 +1,15 @@
 import os
 import shutil
 import unittest
-import tess_atlas.data as tess_data
+
 import pandas as pd
+
+import tess_atlas.data as tess_data
 
 CLEAN_AFTER_TEST = False
 
-class TestData(unittest.TestCase):
 
+class TestData(unittest.TestCase):
     def setUp(self):
         self.orig_dir = os.getcwd()
         self.outdir = "data_test_outdir"
@@ -24,5 +26,5 @@ class TestData(unittest.TestCase):
         self.assertIsInstance(data.to_dataframe(), pd.DataFrame)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+import unittest
+import tess_atlas.data as tess_data
+import pandas as pd
+
+CLEAN_AFTER_TEST = False
+
+class TestData(unittest.TestCase):
+
+    def setUp(self):
+        self.orig_dir = os.getcwd()
+        self.outdir = "data_test_outdir"
+        os.makedirs(self.outdir, exist_ok=True)
+        os.chdir(self.outdir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        if os.path.exists(self.outdir) and CLEAN_AFTER_TEST:
+            shutil.rmtree(self.outdir)
+
+    def test_data_download(self):
+        data = tess_data.TICEntry.generate_tic_from_toi_number(toi=103)
+        self.assertIsInstance(data.to_dataframe(), pd.DataFrame)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_load_samples_demo.py
+++ b/tests/test_load_samples_demo.py
@@ -30,7 +30,9 @@ def create_fake_sample_files(version):
         pm.Uniform("b[0]", 0, 20)
         pm.Uniform("r[0]", 0, 20)
         trace = pm.sample(draws=10, n_init=1, chains=1, tune=10)
-    tic_entry = TICEntry(tic_number=DATA["TIC"], candidates=[], toi=DATA["TOI"])
+    tic_entry = TICEntry(
+        tic_number=DATA["TIC"], candidates=[], toi=DATA["TOI"]
+    )
     tic_entry.inference_trace = trace
     fname = os.path.join(get_outdir(), f"toi_{DATA['TOI']}.netcdf")
     tic_entry.save_inference_trace(fname)

--- a/tests/test_load_samples_demo.py
+++ b/tests/test_load_samples_demo.py
@@ -30,7 +30,7 @@ def create_fake_sample_files(version):
         pm.Uniform("b[0]", 0, 20)
         pm.Uniform("r[0]", 0, 20)
         trace = pm.sample(draws=10, n_init=1, chains=1, tune=10)
-    tic_entry = TICEntry(tic=DATA["TIC"], candidates=[], toi=DATA["TOI"])
+    tic_entry = TICEntry(tic_number=DATA["TIC"], candidates=[], toi=DATA["TOI"])
     tic_entry.inference_trace = trace
     fname = os.path.join(get_outdir(), f"toi_{DATA['TOI']}.netcdf")
     tic_entry.save_inference_trace(fname)

--- a/tests/test_template_notebook.py
+++ b/tests/test_template_notebook.py
@@ -10,8 +10,8 @@ import nbformat
 from tess_atlas import run_toi
 from tess_atlas.tess_atlas_version import __version__
 
-SINGLE_TRANSIT = 103
-MULTI_TRANSIT = 178  # has 3 planets
+SINGLE_PLANET = 103
+MULTI_PLANET = 178  # has 3 planets
 
 
 class NotebookRunnerTestCase(unittest.TestCase):
@@ -40,10 +40,10 @@ class NotebookRunnerTestCase(unittest.TestCase):
             self.fail(f"{notebook_fn} is an invalid notebook")
 
     def test_slow_notebook_execution(self):
-        notebook_execution(MULTI_TRANSIT, version=__version__, quickrun=False)
+        notebook_execution(MULTI_PLANET, version=__version__, quickrun=False)
 
     def test_quick_notebook_execution(self):
-        notebook_execution(MULTI_TRANSIT, version=self.version, quickrun=True)
+        notebook_execution(SINGLE_PLANET , version=self.version, quickrun=True)
 
 
 def notebook_execution(toi_id, version, quickrun=True, remove_after=False):

--- a/tests/test_template_notebook.py
+++ b/tests/test_template_notebook.py
@@ -43,7 +43,7 @@ class NotebookRunnerTestCase(unittest.TestCase):
         notebook_execution(MULTI_PLANET, version=__version__, quickrun=False)
 
     def test_quick_notebook_execution(self):
-        notebook_execution(SINGLE_PLANET , version=self.version, quickrun=True)
+        notebook_execution(SINGLE_PLANET, version=self.version, quickrun=True)
 
 
 def notebook_execution(toi_id, version, quickrun=True, remove_after=False):


### PR DESCRIPTION
There are a couple of time parameters: 
*  `t0`: the mid-transit time of a reference transit for each planet
* `period`: the orbital period with a power-law prior if the TOI is a single transit, or
* `t_max`: the time of the last transit observed by TESS, from which we can compute the period.


For data that has only single transits, we can sample `tmax` in place of `period`  because it's easier to constrain the ranges of `tmax`

This MR tries to add tmax into our model
