### PR TITLE
only use SPOC data with high quality

### DIFF
--- a/src/tess_atlas/data/exofop.py
+++ b/src/tess_atlas/data/exofop.py
@@ -9,7 +9,7 @@ from tess_atlas.utils import NOTEBOOK_LOGGER_NAME
 logger = logging.getLogger(NOTEBOOK_LOGGER_NAME)
 
 EXOFOP = "https://exofop.ipac.caltech.edu/tess/"
-TIC_DATASOURCE = EXOFOP + "download_toi.php?sort=toi&output=csv"
+TIC_DATASOURCE = EXOFOP + "download_toi.php?sort=toi&output=csv&source=spoc"
 TIC_SEARCH = EXOFOP + "target.php?id={tic_id}"
 
 DIR = os.path.dirname(__file__)

--- a/src/tess_atlas/data/lightcurve_data.py
+++ b/src/tess_atlas/data/lightcurve_data.py
@@ -39,7 +39,9 @@ class LightCurveData(DataObject):
         """Uses lightkurve to get TESS data for a TIC from MAST"""
 
         logger.info("Downloading LightCurveData from MAST")
-        search = lk.search_lightcurve(target=f"TIC {tic}", mission="TESS", author="SPOC")
+        search = lk.search_lightcurve(
+            target=f"TIC {tic}", mission="TESS", author="SPOC"
+        )
         logger.debug(f"Search  succeeded: {search}")
 
         # Restrict to short cadence no "fast" cadence
@@ -56,7 +58,7 @@ class LightCurveData(DataObject):
         data = search.download_all(
             download_dir=cache_dir,
             flux_column="pdcsap_flux",
-            quality_bitmask="hard"
+            quality_bitmask="hard",
         )
         if data is None:
             raise ValueError(f"No light curves for TIC {tic}")

--- a/src/tess_atlas/data/lightcurve_data.py
+++ b/src/tess_atlas/data/lightcurve_data.py
@@ -39,7 +39,7 @@ class LightCurveData(DataObject):
         """Uses lightkurve to get TESS data for a TIC from MAST"""
 
         logger.info("Downloading LightCurveData from MAST")
-        search = lk.search_lightcurve(target=f"TIC {tic}", mission="TESS")
+        search = lk.search_lightcurve(target=f"TIC {tic}", mission="TESS", author="SPOC")
         logger.debug(f"Search  succeeded: {search}")
 
         # Restrict to short cadence no "fast" cadence
@@ -50,7 +50,14 @@ class LightCurveData(DataObject):
             f"(TIC {tic})"
         )
         cache_dir = get_cache_dir(default=outdir)
-        data = search.download_all(download_dir=cache_dir)
+
+        # see lightkurve docs on quality flags:
+        # http://docs.lightkurve.org/reference/api/lightkurve.SearchResult.download_all.html
+        data = search.download_all(
+            download_dir=cache_dir,
+            flux_column="pdcsap_flux",
+            quality_bitmask="hard"
+        )
         if data is None:
             raise ValueError(f"No light curves for TIC {tic}")
         logger.info("Completed light curve data download")


### PR DESCRIPTION
- Filter TOIs --> TOIs with `source=spoc` (brings TOI list ~5k -> 1.7k) 
- Set lightcurve data quality flag from "default"->"hard" ([we have option to go to "hardest"](http://docs.lightkurve.org/reference/api/lightkurve.SearchResult.download_all.html#lightkurve-searchresult-download-all) but this is not recommended)

this may help with #167 