### PR TITLE
change sigma=7->10

### DIFF
--- a/src/tess_atlas/data/lightcurve_data.py
+++ b/src/tess_atlas/data/lightcurve_data.py
@@ -64,7 +64,7 @@ class LightCurveData(DataObject):
             raise ValueError(f"No light curves for TIC {tic}")
         logger.info("Completed light curve data download")
         data = data.stitch()
-        data = data.remove_nans().remove_outliers(sigma=7)
+        data = data.remove_nans().remove_outliers(sigma=10)
         t = data.time.value
         inds = np.argsort(t)
         return cls(


### PR DESCRIPTION
TOI 334 (see #167 ) is missing some data. This is because it was incorrectly removed during the lk download step.

![Screenshot 2022-01-17 at 4 38 57 PM](https://user-images.githubusercontent.com/15642823/149713852-0a547711-9969-48e8-8164-623a13bb583b.png)

![Screenshot 2022-01-17 at 4 39 04 PM](https://user-images.githubusercontent.com/15642823/149713858-7f9e01c3-3e28-422d-aceb-9778b18e51b9.png)

Changing the `remov_outlier sigma` param from 7 to 10. Hopefully, this fixes the issue!  