### PR TITLE
+ gp postproc fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
   - id: debug-statements
 
 - repo: https://github.com/psf/black
-  rev: 19.3b0
+  rev: 22.3.0
   hooks:
   - id: black

--- a/src/tess_atlas/analysis/model_tools.py
+++ b/src/tess_atlas/analysis/model_tools.py
@@ -60,6 +60,7 @@ def compute_variable(
     model: Model,
     samples: List[List[float]],
     target: Union[TensorVariable, List[TensorVariable]],
+    verbose: Optional[bool] = True,
 ) -> Union[np.ndarray, Tuple[np.ndarray]]:
     """Computes value for a model variable.
 
@@ -80,7 +81,10 @@ def compute_variable(
 
     #  run post-processing
     results = [
-        func(*s) for s in tqdm(samples, desc="Computing model variable")
+        func(*s)
+        for s in tqdm(
+            samples, desc="Computing model variable", disable=not verbose
+        )
     ]
 
     if isinstance(target, TensorVariable):

--- a/src/tess_atlas/data/inference_data_tools.py
+++ b/src/tess_atlas/data/inference_data_tools.py
@@ -84,6 +84,15 @@ def get_posterior_samples(
     )
 
 
+def get_median_sample(
+    inference_data, varnames: List[str]
+) -> List[List[float]]:
+    """Get the median sample for each param"""
+    samples = get_posterior_samples(inference_data, varnames)
+    param_lists = [np.stack(param_list) for param_list in samples.T]
+    return [np.median(p, axis=0) for p in param_lists]
+
+
 def convert_to_samples_dict(varnames: List[str], samples: np.ndarray):
     """samples obtained from get_posterior_samples"""
     samples_dict = {}

--- a/src/tess_atlas/plotting/plotting_utils.py
+++ b/src/tess_atlas/plotting/plotting_utils.py
@@ -11,6 +11,7 @@ from matplotlib.ticker import ScalarFormatter
 from tess_atlas.data.inference_data_tools import (
     get_posterior_samples,
     get_samples_dataframe,
+    get_median_sample,
 )
 
 from ..analysis import compute_variable, get_untransformed_varnames
@@ -185,13 +186,15 @@ def get_lc_and_gp_from_inference_object(model, inference_data, n=1000):
     samples = get_posterior_samples(
         inference_data=inference_data, varnames=varnames, size=n
     )
-    lcs, gp_mus = compute_variable(
-        model=model,
-        samples=samples,
-        target=[model.lightcurve_models, model.gp_mu],
+    median_sample = get_median_sample(
+        inference_data=inference_data, varnames=varnames
+    )
+    lcs = compute_variable(model, samples, target=model.lightcurve_models)
+    gp_mu = compute_variable(
+        model, [median_sample], target=model.gp_mu, verbose=False
     )
     lcs = lcs * 1e3  # scale the lcs
-    gp_model = np.median(gp_mus, axis=0) + f0
+    gp_model = gp_mu[0] + f0
     return lcs, gp_model
 
 


### PR DESCRIPTION
close #192

Computing the GP for 1000s of posterior samples in post-processing is expensive. Instead, we will compute the GP for the `median(posterior samples)`. 