### PR TITLE
fix p_unc label

### DIFF
--- a/src/tess_atlas/plotting/phase_plotter.py
+++ b/src/tess_atlas/plotting/phase_plotter.py
@@ -25,7 +25,6 @@ from .labels import (
 from .plotting_utils import (
     get_colors,
     get_lc_and_gp_from_inference_object,
-    get_longest_unbroken_section_of_data,
     fold_data,
     generate_model_lightcurve,
     fold_lightcurve_models,
@@ -108,8 +107,9 @@ def plot_phase(
 
 def _get_period_txt(p_std, p_mean):
     # generate period txt
-    unc = f" \\pm {p_std:.2f}" if p_std else ""
-    unc = "" if p_std < 0.001 else unc
+    unc = ""
+    if p_std:
+        unc = "" if p_std < 0.001 else f" \\pm {p_std:.2f}"
     return f"$P = {p_mean:.2f}{unc}$ [days]"
 
 


### PR DESCRIPTION
To fix: 

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/tmp/ipykernel_18734/3481828408.py in <module>
      3 )
      4 plot_phase(**params, thumbnail=True)
----> 5 plot_phase(**params, plot_all_datapoints=True)

/fred/oz200/avajpeyi/projects/tess-atlas/src/tess_atlas/plotting/phase_plotter.py in plot_phase(tic_entry, model, inference_data, initial_params, **kwgs)
    104         fig = plt.figure(figsize=figsize)
    105         ax = fig.gca()
--> 106         add_phase_data_to_ax(ax, i, tic_entry, **kwgs)
    107
    108

/fred/oz200/avajpeyi/projects/tess-atlas/src/tess_atlas/plotting/phase_plotter.py in add_phase_data_to_ax(ax, i, tic_entry, gp_model, posterior, lcs, initial_lightcurves, model_samples, inference_data, initial_params, data_bins, plot_error_bars, plot_data_ci, plot_all_datapoints, zoom_y_axis, plot_label, num_lc, thumbnail, default_fs, period_fs, legend_fs, ms, annotate_with_period, savekwgs, save, legend, **kwgs)
    254     if annotate_with_period:
    255         ann = ax.annotate(
--> 256             _get_period_txt(p_std, p_mean),
    257             (0, 0),
    258             xycoords="axes fraction",

/fred/oz200/avajpeyi/projects/tess-atlas/src/tess_atlas/plotting/phase_plotter.py in _get_period_txt(p_std, p_mean)
    110     # generate period txt
    111     unc = f" \\pm {p_std:.2f}" if p_std else ""
--> 112     unc = "" if p_std < 0.001 else unc
    113     return f"$P = {p_mean:.2f}{unc}$ [days]"
    114

TypeError: '<' not supported between instances of 'NoneType' and 'float'
TypeError: '<' not supported between instances of 'NoneType' and 'float'

[00:08:03 - TESS-ATLAS-RUNNER] TOI 2270 execution complete: False (478.95s)
```