### PR TITLE
make new submodule for webbuilding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tess_atlas_webbuilder"]
+	path = tess_atlas_webbuilder
+	url = git@github.com:avivajpeyi/tess_atlas_webbuilder.git

--- a/src/tess_atlas/cli/make_webpages_cli.py
+++ b/src/tess_atlas/cli/make_webpages_cli.py
@@ -38,6 +38,7 @@ def get_cli_args():
 
 def main():
     args = get_cli_args()
+
     build_website(
         builddir=args.webdir,
         notebook_dir=args.notebooks,

--- a/src/tess_atlas/webbuilder/webbuilder.py
+++ b/src/tess_atlas/webbuilder/webbuilder.py
@@ -136,6 +136,11 @@ def build_website(
         (this will take some time -- requires copying all notebooks/data)
 
     """
+    # Deprecation warning
+    logger.warning(
+        "This function will be deprecated. Use tess_atlas_webbuilder instead."
+    )
+
     p = WebBuilder(
         notebook_src=notebook_dir,
         builddir=builddir,


### PR DESCRIPTION
Users of the TESS-Atlas package wouldn't care about using the TESS-Atlas web-building utils. Only the devs (me) would need that. Im moving the sphinx/webbuilding stuff to another repo where that can be tested/deployed separately. 

